### PR TITLE
issue-108 : implemented ElasticsearchClient

### DIFF
--- a/server/controllers/ElasticsearchClient.js
+++ b/server/controllers/ElasticsearchClient.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var ElasticsearchClient = require('../service/ElasticsearchClientService');
+var responseBuilder = require('onf-core-model-ap/applicationPattern/rest/server/ResponseBuilder');
+var responseCodeEnum = require('onf-core-model-ap/applicationPattern/rest/server/ResponseCode');
+var oamLogService = require('onf-core-model-ap/applicationPattern/services/OamLogService');
+
+module.exports.getElasticsearchClientApiKey = async function getElasticsearchClientApiKey (req, res, next, uuid) {
+  let responseCode = responseCodeEnum.code.OK;
+  await ElasticsearchClient.getElasticsearchClientApiKey(req.url)
+    .then(function (response) {
+      responseBuilder.buildResponse(res, responseCode, response);
+    })
+    .catch(function (response) {
+      responseCode = responseCodeEnum.code.INTERNAL_SERVER_ERROR;
+      responseBuilder.buildResponse(res, responseCode, response);
+    });
+  oamLogService.recordOamRequest(req.url, req.body, responseCode, req.headers.authorization, req.method);
+};
+
+module.exports.getElasticsearchClientIndexAlias = async function getElasticsearchClientIndexAlias (req, res, next, uuid) {
+  let responseCode = responseCodeEnum.code.OK;
+  await ElasticsearchClient.getElasticsearchClientIndexAlias(req.url)
+    .then(function (response) {
+      responseBuilder.buildResponse(res, responseCode, response);
+    })
+    .catch(function (response) {
+      responseCode = responseCodeEnum.code.INTERNAL_SERVER_ERROR;
+      responseBuilder.buildResponse(res, responseCode, response);
+    });
+  oamLogService.recordOamRequest(req.url, req.body, responseCode, req.headers.authorization, req.method);
+};
+
+module.exports.getElasticsearchClientLifeCycleState = async function getElasticsearchClientLifeCycleState (req, res, next, uuid) {
+  let responseCode = responseCodeEnum.code.OK;
+  await ElasticsearchClient.getElasticsearchClientLifeCycleState(req.url)
+    .then(function (response) {
+      responseBuilder.buildResponse(res, responseCode, response);
+    })
+    .catch(function (response) {
+      responseCode = responseCodeEnum.code.INTERNAL_SERVER_ERROR;
+      responseBuilder.buildResponse(res, responseCode, response);
+    });
+  oamLogService.recordOamRequest(req.url, req.body, responseCode, req.headers.authorization, req.method);
+};
+
+module.exports.getElasticsearchClientOperationalState = async function getElasticsearchClientOperationalState (req, res, next, uuid) {
+  let responseCode = responseCodeEnum.code.OK;
+  await ElasticsearchClient.getElasticsearchClientOperationalState(req.url, uuid)
+    .then(function (response) {
+      responseBuilder.buildResponse(res, responseCode, response);
+    })
+    .catch(function (response) {
+      responseCode = responseCodeEnum.code.INTERNAL_SERVER_ERROR;
+      responseBuilder.buildResponse(res, responseCode, response);
+    });
+  oamLogService.recordOamRequest(req.url, req.body, responseCode, req.headers.authorization, req.method);
+};
+
+module.exports.getElasticsearchClientServiceRecordsPolicy = async function getElasticsearchClientServiceRecordsPolicy (req, res, next, uuid) {
+  let responseCode = responseCodeEnum.code.OK;
+  await ElasticsearchClient.getElasticsearchClientServiceRecordsPolicy(uuid)
+  .then(function (response) {
+    responseBuilder.buildResponse(res, responseCode, response);
+  })
+  .catch(function (response) {
+    responseCode = responseCodeEnum.code.INTERNAL_SERVER_ERROR;
+    responseBuilder.buildResponse(res, responseCode, response);
+  });
+  oamLogService.recordOamRequest(req.url, req.body, responseCode, req.headers.authorization, req.method);
+};
+
+module.exports.putElasticsearchClientApiKey = async function putElasticsearchClientApiKey (req, res, next, body, uuid) {
+  let responseCode = responseCodeEnum.code.NO_CONTENT;
+  await ElasticsearchClient.putElasticsearchClientApiKey(req.url, body)
+    .then(function (response) {
+      responseBuilder.buildResponse(res, responseCode, response);
+    })
+    .catch(function (response) {
+      responseCode = responseCodeEnum.code.INTERNAL_SERVER_ERROR;
+      responseBuilder.buildResponse(res, responseCode, response);
+    });
+  oamLogService.recordOamRequest(req.url, req.body, responseCode, req.headers.authorization, req.method);
+};
+
+module.exports.putElasticsearchClientIndexAlias = async function putElasticsearchClientIndexAlias (req, res, next, body, uuid) {
+  let responseCode = responseCodeEnum.code.NO_CONTENT;
+  await ElasticsearchClient.putElasticsearchClientIndexAlias(req.url, body)
+    .then(function (response) {
+      responseBuilder.buildResponse(res, responseCode, response);
+    })
+    .catch(function (response) {
+      responseCode = responseCodeEnum.code.INTERNAL_SERVER_ERROR;
+      responseBuilder.buildResponse(res, responseCode, response);
+    });
+  oamLogService.recordOamRequest(req.url, req.body, responseCode, req.headers.authorization, req.method);
+};
+
+module.exports.putElasticsearchClientServiceRecordsPolicy = async function putElasticsearchClientServiceRecordsPolicy (req, res, next, body, uuid) {
+  let responseCode = responseCodeEnum.code.NO_CONTENT;
+  await ElasticsearchClient.putElasticsearchClientServiceRecordsPolicy(uuid, body)
+    .then(function (response) {
+      responseBuilder.buildResponse(res, responseCode, response);
+    })
+    .catch(function (response) {
+      responseCode = responseCodeEnum.code.INTERNAL_SERVER_ERROR;
+      responseBuilder.buildResponse(res, responseCode, response);
+    });
+  oamLogService.recordOamRequest(req.url, req.body, responseCode, req.headers.authorization, req.method);
+};

--- a/server/service/ElasticsearchClientService.js
+++ b/server/service/ElasticsearchClientService.js
@@ -92,7 +92,6 @@ exports.getElasticsearchClientOperationalState = function(url, uuid) {
       response['application/json'] = {
         "elasticsearch-client-interface-1-0:operational-state" : value
       };
-      await fileOperation.writeToDatabaseAsync(url, value, false);
       if (Object.keys(response).length > 0) {
         resolve(response[Object.keys(response)[0]]);
       } else {

--- a/server/service/ElasticsearchClientService.js
+++ b/server/service/ElasticsearchClientService.js
@@ -1,0 +1,184 @@
+'use strict';
+var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver/JSONDriver');
+const elasticsearchService = require('onf-core-model-ap/applicationPattern/services/ElasticsearchService');
+
+/**
+ * Returns API key
+ *
+ * url String
+ * returns inline_response_200_50
+ **/
+exports.getElasticsearchClientApiKey = function(url) {
+  return new Promise(async function(resolve, reject) {
+    try {
+      var value = await fileOperation.readFromDatabaseAsync(url);
+      var response = {};
+      response['application/json'] = {
+        "elasticsearch-client-interface-1-0:api-key" : value
+      };
+      if (Object.keys(response).length > 0) {
+        resolve(response[Object.keys(response)[0]]);
+      } else {
+        resolve();
+      }
+    } catch (error) {
+      reject();
+    }
+  });
+}
+
+/**
+ * Returns index alias
+ *
+ * url String
+ * returns inline_response_200_51
+ **/
+exports.getElasticsearchClientIndexAlias = function(url) {
+  return new Promise(async function(resolve, reject) {
+    try {
+      var value = await fileOperation.readFromDatabaseAsync(url);
+      var response = {};
+      response['application/json'] = {
+        "elasticsearch-client-interface-1-0:index-alias" : value
+      };
+      if (Object.keys(response).length > 0) {
+        resolve(response[Object.keys(response)[0]]);
+      } else {
+        resolve();
+      }
+    } catch (error) {
+      reject();
+    }
+  });
+}
+
+/**
+ * Returns life cycle state of the connection towards Elasticsearch
+ *
+ * url String
+ * returns inline_response_200_54
+ **/
+exports.getElasticsearchClientLifeCycleState = function(url) {
+  return new Promise(async function(resolve, reject) {
+    try {
+      var value = await fileOperation.readFromDatabaseAsync(url);
+      var response = {};
+      response['application/json'] = {
+        "elasticsearch-client-interface-1-0:life-cycle-state" : value
+      };
+      if (Object.keys(response).length > 0) {
+        resolve(response[Object.keys(response)[0]]);
+      } else {
+        resolve();
+      }
+    } catch (error) {
+      reject();
+    }
+  });
+}
+
+/**
+ * Returns operational state of the connection towards Elasticsearch
+ *
+ * url String
+ * uuid String
+ * returns inline_response_200_53
+ **/
+exports.getElasticsearchClientOperationalState = function(url, uuid) {
+  return new Promise(async function(resolve, reject) {
+    try {
+      let value = await elasticsearchService.getElasticsearchClientOperationalStateAsync(uuid);
+      var response = {};
+      response['application/json'] = {
+        "elasticsearch-client-interface-1-0:operational-state" : value
+      };
+      await fileOperation.writeToDatabaseAsync(url, value, false);
+      if (Object.keys(response).length > 0) {
+        resolve(response[Object.keys(response)[0]]);
+      } else {
+        resolve();
+      }
+    } catch (error) {
+      reject();
+    }
+  });
+}
+
+/**
+ * Returns service records policy
+ *
+ * uuid String
+ * returns inline_response_200_52
+ **/
+exports.getElasticsearchClientServiceRecordsPolicy = function(uuid) {
+  return new Promise(async function(resolve, reject) {
+    try {
+      var value = await elasticsearchService.getElasticsearchClientServiceRecordsPolicyAsync(uuid);
+      var response = {};
+      response['application/json'] = {
+        "elasticsearch-client-interface-1-0:service-records-policy" : value
+      };
+      if (Object.keys(response).length > 0) {
+        resolve(response[Object.keys(response)[0]]);
+      } else {
+        resolve();
+      }
+    } catch (error) {
+      reject();
+    }
+  });
+}
+
+/**
+ * Configures API key
+ *
+ * body Auth_apikey_body
+ * url String
+ * no response value expected for this operation
+ **/
+exports.putElasticsearchClientApiKey = function(url, body) {
+  return new Promise(async function (resolve, reject) {
+    try {
+      await fileOperation.writeToDatabaseAsync(url, body, false);
+      resolve();
+    } catch (error) {
+      reject();
+    }
+  });
+}
+
+/**
+ * Configures index alias
+ *
+ * body Elasticsearchclientinterfaceconfiguration_indexalias_body
+ * url String
+ * no response value expected for this operation
+ **/
+exports.putElasticsearchClientIndexAlias = function(url, body) {
+  return new Promise(async function (resolve, reject) {
+    try {
+      await fileOperation.writeToDatabaseAsync(url, body, false);
+      resolve();
+    } catch (error) {
+      reject();
+    }
+  });
+}
+
+  /**
+ * Configures service records policy
+ *
+ * body Elasticsearchclientinterfaceconfiguration_servicerecordspolicy_body
+ * uuid String
+ * no response value expected for this operation
+ **/
+exports.putElasticsearchClientServiceRecordsPolicy = function(uuid, body) {
+  return new Promise(async function(resolve, reject) {
+    try {
+      await elasticsearchService.putElasticsearchClientServiceRecordsPolicyAsync(uuid, body);
+      resolve();
+    } catch (error) {
+      reject();
+    }
+  });
+}


### PR DESCRIPTION
- operations getElasticsearchClientOperationalState, getElasticsearchClientServiceRecordsPolicy, putElasticsearchClientServiceRecordsPolicy do not read/write data to config, they go directly to Elasticsearch instance

Fixes #108 

Signed-off-by: Dana Sunalova <dana@paxet.io>